### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The implementation details of the Store  and their variations can be quite impor
 This is Reduks in brief. let us now discuss it more in detail
 
 <a name="the_state"></a>
-##The State
+## The State
 The state is the set of data that uniquely identify the current state of the application. 
 Typically in Android, this is the state of the current Activity.
 
@@ -129,7 +129,7 @@ fun copy(email: String?=null, password:String?=null, emailConfirmed:Boolean?=nul
 ```
 
 <a name="subscribers"></a>
-###State Change Subscribers
+### State Change Subscribers
 Before we discuss how the state changes, let's see how we listen to those changes. 
 Through the store method
 ```kotlin
@@ -192,7 +192,7 @@ Selectors can detect quite efficiently changes in the state, thanks to a techniq
 Look [here](./reduks/src/test/kotlin/com/beyondeye/reduks/ReselectTest.kt) for more examples on how to build selectors.
 
 <a name="actions"></a>  
-###Actions and Reducers
+### Actions and Reducers
 As we mentioned above, whenever we want to change the state of the application we need to send(dispatch) an *Action*  object, that will be processed by the *Reducers*,
 that are pure functions that take as input the action and the current state and outputs a new modified state.
 An action object can be literally any object. For example we can define the following actions
@@ -203,7 +203,7 @@ class LoginAction {
     class EmailConfirmed
 }
 ```
-####Reducers
+#### Reducers
 a sample [Reducer](./reduks/src/main/java/com/beyondeye/reduks/Reducer.java) can be the following 
 ```kotlin
 val reducer = ReducerFn<LoginActivityState> { state, action ->
@@ -218,7 +218,7 @@ val reducer = ReducerFn<LoginActivityState> { state, action ->
 Reducers must be pure functions, without side-effects except for updating the state. In particular in a reducer you cannot dispatch actions
 
 <a name="sealedclasses"></a>  
-####Better Actions with Kotlin sealed classes
+#### Better Actions with Kotlin sealed classes
 You may have noticed a potential source of bugs in our previous reducer code. There is a risk that we simply forget to enumerate all action types in the ```when``` expression.
 
 We can catch this type of errors at compile time thanks to [ Kotlin sealed classes](https://kotlinlang.org/docs/reference/classes.html#sealed-classes).
@@ -248,7 +248,7 @@ Note that the exhaustive check is activated only for [when expressions](https://
 the  ```when``` block, like in the code above.
 
 <a name="standardaction"></a>  
-####Even Better Actions with Reduks StandardAction
+#### Even Better Actions with Reduks StandardAction
 Reduks  [StandardAction](./reduks/src/main/kotlin/com/beyondeye/reduks/StandardAction.kt) is a base interface for actions that provide a standard way to define actions also for failed/async operations:
  
 ```kotlin
@@ -300,7 +300,7 @@ val reducer2 = ReducerFn<LoginActivityState2> { s, a ->
 ```
 
 <a name="combinereducers"></a>
-####Combining Reducers
+#### Combining Reducers
 When your application start getting complex, your reducer code will start getting difficult too manage.
 To solve this problem, Reduks provide the method ```combineReducers``` that allows  splitting the definition of the reducer and even put each part of the definition in a different file. 
 
@@ -351,7 +351,7 @@ Note that this is different from how it works in   [reduxjs combineReducers](htt
 implemented and extended in Reduks Modules (see below)
 
 <a name="dispatch_from_reducer"></a>
-####If I feel like I want to dispatch from my Reducer what is the correct thing to do instead?
+#### If I feel like I want to dispatch from my Reducer what is the correct thing to do instead?
 This is one of the most typical things that confuse beginners.
 
 For example let's say that in order to verify the email address at user registration we must
@@ -375,15 +375,15 @@ If you find yourself in this situation then you should defer dispatching an acti
 At a later stage you can eventually also split the chain into multiple actions (so that you can update the UI at different stages of the user authentication process), 
 but always keep the chain logic in the original place. We will discuss later the [Thunk middleware](./reduks/src/main/kotlin/com/beyondeye/reduks/middlewares/ThunkMiddleware.kt)
 and [AsyncAction middleware](./reduks-kovenant/src/main/kotlin/com/beyondeye/reduks/middlewares/AsyncActionMiddleWare.kt) that will help you handle these chains of actions better
-###Reduks Modules
+### Reduks Modules
 TODO
-####Combining Reduks modules
+#### Combining Reduks modules
 TODO
-###Reduks Activity
+### Reduks Activity
 TODO
 
 <a name="pcollections"></a>
-####Immutable (Persistent) Collections with Reduks
+#### Immutable (Persistent) Collections with Reduks
 A critical component, from a performance point of view, when defining complex Reduks states are so called _persistent collections_ , that is collections
 that when modified always create a copy of the original collection, with efficient data sharing mechanims between multiple versions of the modified collections.
 Unfortunately there are not yet persistent collection in kotlin standard library (there is [a proposal](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/proposal.md)).
@@ -398,7 +398,7 @@ Although it is not the most efficient implementation, it is not too far behind f
 for reduks bus store enhancer (see below)
 
 <a name="reduksbus"></a>
-####Reduks bus: a communication channel between fragments
+#### Reduks bus: a communication channel between fragments
 The official method in Android for communicating results from a fragment to the parent activity or between fragments are [callback interfaces](http://developer.android.com/training/basics/fragments/communicating.html).
 This design pattern is very problematic, as it is proven by the success of libraries like [Square Otto](https://github.com/square/otto) and [GreenRobot EventBus](https://github.com/greenrobot/EventBus).
 Reduks architecture has actually severally things in common with  an event bus 
@@ -462,7 +462,7 @@ But first let's see how we post some data on the bus:
  store.postBusData(LoginFragmentResult(username = "Kotlin", password = "IsAwsome"))
 ```
 That's it. See more code examples [here](./reduks-bus/src/test/kotlin/com/beyondeye/reduks/bus/BusStoreEnhancerTest.kt). For the full Api see [here](./reduks-bus/src/main/kotlin/com/beyondeye/reduks/bus/busApi.kt)
-#####Reduks bus under the hood
+##### Reduks bus under the hood
 What's happening when we post some data on the bus? What we are doing is actualling dispatching the Action
 ```kotlin
 class ActionSendBusData(val key: String, val newData: Any)
@@ -481,7 +481,7 @@ the `no data present` state is triggered when we call
 store.clearBusData<LoginFragmentResult>()
 ```
 that will clear the bus data for the specified object type and trigger the bus data handler with a null value as input.
-####Reduks bus in Android Fragments
+#### Reduks bus in Android Fragments
 Finally we can show the code for handling communication  between a Fragment and a parent activity, or another Fragment.
 We assume that the parent activity implement the [ReduksActivity interface](./reduks-android/src/main/kotlin/com/beyondeye/reduksAndroid/activity/ReduksActivity.kt)
 ```kotlin
@@ -525,27 +525,27 @@ class LoginDataDisplayFragment : Fragment() {
 ```
 Notices that we are using the Fragment tag (assuming it is defined) for automatically keeping track of all registered bus data handlers and removing them when the Fragment is detached from the activity
 for the full source code of the example discussed see [here](./code_fragments/src/main/java/beyondeye/com/examples/busExample.kt) 
-####Persisting Reduks state and activity lifecycle
+#### Persisting Reduks state and activity lifecycle
 TODO
-###Middlewares
+### Middlewares
 TODO
-####Thunk Middleware
+#### Thunk Middleware
 TODO
-####Promise Middleware
+#### Promise Middleware
 TODO
-####Logger Middleware
+#### Logger Middleware
 TODO
-###Types of Reduks Stores
+### Types of Reduks Stores
 TODO
-####Simple Store
+#### Simple Store
 TODO
-####RxJava based Store
+#### RxJava based Store
 TODO
-####Promise based (Kovenant) Store
+#### Promise based (Kovenant) Store
 TODO
-###Store Enhancers
+### Store Enhancers
 TODO
-####Reduks DevTools
+#### Reduks DevTools
 TODO
 
 <a name="opensource"></a>

--- a/README_pcollections.md
+++ b/README_pcollections.md
@@ -6,12 +6,12 @@ A Persistent Java Collections Library
 [![Maven Central](https://img.shields.io/maven-central/v/org.pcollections/pcollections.svg)](https://maven-badges.herokuapp.com/maven-central/org.pcollections/pcollections/)
 [![Javadoc](https://javadoc-emblem.rhcloud.com/doc/org.pcollections/pcollections/badge.svg)](http://www.javadoc.io/doc/org.pcollections/pcollections)
 
-###Overview
+### Overview
 
 PCollections serves as a [persistent](http://en.wikipedia.org/wiki/Persistent_data_structure) and immutable analogue of the [Java Collections Framework](http://java.sun.com/javase/6/docs/technotes/guides/collections/index.html). This includes **efficient**, **thread-safe**, **generic**, **immutable**, and **persistent** stacks, maps, vectors, sets, and bags, **compatible** with their Java Collections counterparts.
 
 Persistent and immutable datatypes are increasingly appreciated as a **simple**, **design-friendly**, **concurrency-friendly**, and sometimes more time- and space-efficient alternative to mutable datatypes.
-###Persistent versus Unmodifiable
+### Persistent versus Unmodifiable
 
 Note that these immutable collections are very different from the immutable collections returned by Java's [Collections.unmodifiableCollection()](http://java.sun.com/javase/6/docs/api/java/util/Collections.html#unmodifiableCollection(java.util.Collection)) and similar methods. The difference is that Java's unmodifiable collections have no producers, whereas PCollections have very efficient producers. Thus if you have an unmodifiable Collection x and you want a new Collection x2 consisting of the elements of x in addition to some element e, you would have to do something like:
 ```Java
@@ -23,7 +23,7 @@ which involves copying all of x, using linear time and space. If, on the other h
 PCollection y2 = y.plus(e);
 ```
 which still leaves y untouched but generally requires little or no copying, using time and space much more efficiently.
-###Usage
+### Usage
 
 PCollections are created using producers and static factory methods. Some example static factory methods are [HashTreePSet.empty()](http://pcollections.googlecode.com/svn/trunk/docs/org/pcollections/HashTreePSet.html#empty()) which returns an empty [PSet](http://pcollections.googlecode.com/svn/trunk/docs/org/pcollections/PSet.html), while HashTreePSet.singleton(e) returns a PSet containing just the element e, and HashTreePSet.from(collection) returns a PSet containing the same elements as collection. See 'Example Code' below for an example of using producers.
 
@@ -48,7 +48,7 @@ PCollections is in the [Maven Central repository](http://search.maven.org/#searc
 </dependency>
 ```
 
-###Example Code
+### Example Code
 
 The following gives a very simple example of using PCollections, including the static factory method HashTreePSet.empty() and the producer plus(e):
 ```Java
@@ -72,7 +72,7 @@ Running this program gives the following output:
 [something]
 ```
 
-###Building form source
+### Building form source
 For building the project from source [clone the repository](https://github.com/pcollections/pcollections.git) and then execute
 ```
  ./gradlew build
@@ -83,6 +83,6 @@ This will compile all files, execute the tests and create a jar in ./build/libs.
 * test - to build the project and run the test files
 * compileJava - to only compile the Java files
 
-###Related Work
+### Related Work
 
 [Clojure](http://clojure.googlecode.com/) also provides persistent collections in Java, but for now they are less interoperable with Java Collections, and seem more designed to be used within the Clojure language itself. Both [Guava](http://guava-libraries.googlecode.com/) and Java's [Collections](http://java.sun.com/javase/6/docs/api/java/util/Collections.html) utility class provide immutable collections but they are not persistent, that is they do not provide efficient producers, so they are not nearly as useful. See [Persistent versus Unmodifiable](#persistent-versus-unmodifiable) above. 

--- a/README_zjsonpatch.md
+++ b/README_zjsonpatch.md
@@ -1,27 +1,27 @@
 # This is an implementation of  [RFC 6902 JSON Patch](http://tools.ietf.org/html/rfc6902) written in Java.
 
-##Description & Use-Cases
+## Description & Use-Cases
 - Java Library to find / apply JSON Patches according to RFC 6902.
 - JSON Patch defines a JSON document structure for representing changes to a JSON document.
 - It can be used to avoid sending a whole document when only a part has changed, thus reducing network bandwidth requirements if data (in json format) is required to send across multiple systems over network or in case of multi DC transfer.
 - When used in combination with the HTTP PATCH method as per [RFC 5789 HTTP PATCH](http://tools.ietf.org/html/rfc5789), it will do partial updates for HTTP APIs in a standard  way.
 
 
-###Compatible with : Java 6 / 7 / 8
+### Compatible with : Java 6 / 7 / 8
 
-##Code Coverage
+## Code Coverage
 Package      |	Class, % 	 |  Method, % 	   |  Line, %           |
 -------------|---------------|-----------------|--------------------|
 all classes  |	100% (6/ 6)  |	93.6% (44/ 47) |  96.2% (332/ 345)  |
 
-##Complexity
+## Complexity
 - To find JsonPatch : Ω(N+M) ,N and M represents number of keys in first and second json respectively / O(summation of la*lb) where la , lb represents jsonArray of length la / lb of against same key in first and second json ,since LCS is used to find difference between 2 json arrays there of order of quadratic.
 - To Optimize Diffs ( compact move and remove into Move ) : Ω(D) / O(D*D) where D represents number of diffs obtained before compaction into Move operation.
 - To Apply Diff : O(D) where D represents number of diffs
 
 ### How to use:
 
-###Current Version : 0.2.1
+### Current Version : 0.2.1
 
 Add following to `<dependencies/>` section of your pom.xml -
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
